### PR TITLE
Generic build target

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,9 @@ index.html: main.fnl sample.html ; fennel/fennel main.fnl > index.html
 fennelview.lua: fennel/fennelview.fnl ; fennel/fennel --compile $^ > $@
 generate.lua: fennel/generate.fnl ; fennel/fennel --compile $^ > $@
 
+.DEFAULT_GOAL := build
 HTML := tutorial.html api.html reference.html lua-primer.html changelog.html index.html
+LUA := generate.lua fennelview.lua
 
 PANDOC=pandoc -H head.html -A foot.html -T "Fennel"
 
@@ -13,10 +15,12 @@ reference.html: fennel/reference.md ; $(PANDOC) -o $@ $^
 lua-primer.html: fennel/lua-primer.md ; $(PANDOC) -o $@ $^
 changelog.html: fennel/changelog.md ; $(PANDOC) -o $@ $^
 
+build: $(HTML) $(LUA)
 html: $(HTML)
-clean: ; rm $(HTML)
+lua: $(LUA)
+clean: ; rm $(HTML) $(LUA)
 
-upload: $(HTML) init.lua repl.fnl fennel.css fengari-web.js .htaccess \
+upload: build init.lua repl.fnl fennel.css fengari-web.js .htaccess \
 		fennel fennelview.lua generate.lua
 	rsync -r $^ fenneler@fennel-lang.org:fennel-lang.org/
 
@@ -39,3 +43,5 @@ pullsignups:
 	rsync -rv fenneler@fennel-lang.org:conf.fennel-lang.org/signups/*fnl signups/
 	ls signups/ | wc -l
 	fennel signups.fnl
+
+.PHONY: build html lua clean upload uploadv uploadconf pullsignups

--- a/makefile
+++ b/makefile
@@ -18,10 +18,9 @@ changelog.html: fennel/changelog.md ; $(PANDOC) -o $@ $^
 build: $(HTML) $(LUA)
 html: $(HTML)
 lua: $(LUA)
-clean: ; rm $(HTML) $(LUA)
+clean: ; rm -f $(HTML) $(LUA)
 
-upload: build init.lua repl.fnl fennel.css fengari-web.js .htaccess \
-		fennel fennelview.lua generate.lua
+upload: $(HTML) $(LUA) init.lua repl.fnl fennel.css fengari-web.js .htaccess fennel
 	rsync -r $^ fenneler@fennel-lang.org:fennel-lang.org/
 
 conf/%.html: conf/%.fnl ; fennel/fennel $^ > $@


### PR DESCRIPTION

- Sets a `LUA` variable containing the lua files that need compiling from fennel
- Adds a `build` target for running `make build`
- Sets `build` as the default target so you can just run `make` to build everything
- Updates `make clean` to use `rm -f` so it won't fail if some files are missing.