### PR TITLE
Fix generation of multi tag docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /reference.html
 /signups
 /tutorial.html
+/master
+/v?.?.?


### PR DESCRIPTION
- Generate the versions at top level (no longer pollute the submodule), which
  also makes the pandoc pattern work.
- For now only generate the index for the root; most likely we want a
  different one or at least parameterize it