### PR TITLE
Cleanup multi tag build

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,3 +1,3 @@
-    <link rel="stylesheet" href="fennel.css"></link>
+    <link rel="stylesheet" href="/fennel.css"></link>
     <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css"/>
     <title>the Fennel programming language</title>

--- a/main.fnl
+++ b/main.fnl
@@ -5,9 +5,9 @@
 (print (html [:html {:lang "en"}
               [:head {}
                [:meta {:charset "UTF-8"}]
-               [:script {:src "fengari-web.js"}]
-               [:script {:type "application/lua" :src "init.lua" :async true}]
-               [:link {:rel "stylesheet" :href "fennel.css"}]
+               [:script {:src "/fengari-web.js"}]
+               [:script {:type "application/lua" :src "/init.lua" :async true}]
+               [:link {:rel "stylesheet" :href "/fennel.css"}]
                [:link {:rel "stylesheet"
                        :href "https://code.cdn.mozilla.net/fonts/fira.css"}]
                [:title {} "the Fennel programming language"]]

--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ build: html lua tagdocs
 html: $(HTML) index.html
 tagdocs: tags $(TAGDOCS)
 lua: $(LUA)
-clean: cleantagdirs ; rm -f $(HTML) $(LUA)
+clean: cleantagdirs ; rm -f $(HTML) index.html $(LUA)
 
 upload: $(HTML) $(LUA) $(TAGDOCS) init.lua repl.fnl fennel.css fengari-web.js .htaccess fennel
 	rsync -r $^ fenneler@fennel-lang.org:fennel-lang.org/


### PR DESCRIPTION
Some cleanups for the patches from yesterday:
- `index.html` was generated explicitly but not cleaned.
- Use the linked resources from the webroot (CSS, JS, ...) to make them work also in the tag-dirs.