### PR TITLE
Generate version indices

### DIFF
--- a/main.fnl
+++ b/main.fnl
@@ -101,6 +101,12 @@
                 [:li {} "The" [:a {:href "/changelog"} "Changelog"]
                  "describes how Fennel has evolved with time."]]
 
+               [:p {} "Looking for other versions?  Docs are generated for:"]
+               (let [version-links [:ul {}]]
+                 (each [i version (ipairs arg)]
+                       (table.insert version-links [:li {} [:a {:href version} version]]))
+                 version-links)
+
                [:h2 {} "Development"]
                [:p {} "Fennel's repository is on "
                 [:a {:href "https://github.com/bakpakin/Fennel"} "GitHub"]

--- a/makefile
+++ b/makefile
@@ -1,3 +1,5 @@
+TAGS := $(shell git --git-dir=./fennel/.git tag -l | grep '^[0-9]' | tac)
+
 index.html: main.fnl sample.html ; fennel/fennel main.fnl > index.html
 fennelview.lua: fennel/fennelview.fnl ; fennel/fennel --compile $^ > $@
 generate.lua: fennel/generate.fnl ; fennel/fennel --compile $^ > $@
@@ -12,7 +14,6 @@ PANDOC=pandoc --syntax-definition fennel-syntax.xml \
 
 %.html: fennel/%.md ; $(PANDOC) -o $@ $^
 
-TAGS := 0.1.0 0.1.1 0.2.0 0.2.1
 TAGDIRS := $(foreach tag, $(TAGS), v${tag}) master
 v%/fennel: ; git clone --branch $* fennel $@
 master/fennel: ; git clone --branch master fennel $@

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 TAGS := $(shell git --git-dir=./fennel/.git tag -l | grep '^[0-9]' | tac)
 
-index.html: main.fnl sample.html ; fennel/fennel main.fnl > index.html
+index.html: main.fnl sample.html ; fennel/fennel main.fnl $(TAGS) > index.html
 fennelview.lua: fennel/fennelview.fnl ; fennel/fennel --compile $^ > $@
 generate.lua: fennel/generate.fnl ; fennel/fennel --compile $^ > $@
 


### PR DESCRIPTION
- Generate links from the main index to all generated tag indices
- Generate a combined index for each tag from the main doc files (changelog, api, reference)