### PR TITLE
Point to www.minetest.net

### DIFF
--- a/main.fnl
+++ b/main.fnl
@@ -35,7 +35,7 @@
                [:p {} "Anywhere you can run Lua code, you can run Fennel code."]
 
                [:ul {:id "where"}
-                [:li {} [:a {:href "https://minetest.net/"} "video"]
+                [:li {} [:a {:href "https://www.minetest.net/"} "video"]
                  [:a {:href "https://love2d.org"} "games"]]
                 [:li {} [:a {:href "https://awesomewm.org/"} "window managers"]]
                 [:li {} [:a {:href "https://openresty.org/en/"} "web"]


### PR DESCRIPTION
A current link on the homepage points to https://minetest.net, which has misconfigured SSL, effectively breaking the link.

It appears that www.minetest.net works properly, so this PR updates the link to point there.

Separately this should probably be brought to the minetest folks’ attention.